### PR TITLE
nav dropdown menu fixed to not be visible in desktop view

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -218,7 +218,12 @@ nav .menuBtn {
   color: #0088ff;
 }
 .menu--open {
-  display: block;
+  display: none;
+}
+@media (max-width: 800px) {
+  .menu--open {
+    display: block;
+  }
 }
 footer {
   font-size: 1.6em;

--- a/less/nav.less
+++ b/less/nav.less
@@ -79,5 +79,8 @@ nav {
 }
 
 .menu--open {
-  display: block;
+  display: none;
+  @media @tablet {
+    display:block;
+  }
 }


### PR DESCRIPTION
BUT if it was open in tablet and you go back to tablet it pops back up. maybe add a timeout feature?